### PR TITLE
feat: Highscore-Tabelle im Startmenü verfügbar machen

### DIFF
--- a/ZeroPlay/main.py
+++ b/ZeroPlay/main.py
@@ -10,6 +10,7 @@ from class_selection_frame import ClassSelectionFrame
 from rpg_gui import RpgGui
 from save_load_system import save_game, load_game, get_save_files, SAVE_DIR
 from utils import center_window
+from highscore_gui import HighscoreWindow
 import os
 
 class Game:
@@ -43,9 +44,13 @@ class Game:
         callbacks = {
             'load': self.load_and_show_game,
             'new': self.show_character_creation,
-            'quit': self.quit_game
+            'quit': self.quit_game,
+            'highscores': self.show_highscores
         }
         self.switch_frame(StartMenu, callbacks=callbacks)
+
+    def show_highscores(self):
+        HighscoreWindow(self.root)
 
     def show_character_creation(self):
         callbacks = {

--- a/ZeroPlay/start_menu_gui.py
+++ b/ZeroPlay/start_menu_gui.py
@@ -85,6 +85,9 @@ class StartMenu(ttk.Frame):
         new_game_button = ttk.Button(button_frame, text="Neues Spiel", command=self.callbacks['new'])
         new_game_button.pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
 
+        highscore_button = ttk.Button(button_frame, text="Highscores", command=self.callbacks.get('highscores', lambda: None))
+        highscore_button.pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
+
         quit_button = ttk.Button(button_frame, text="Beenden", command=self.callbacks['quit'])
         quit_button.pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
 


### PR DESCRIPTION
Fügt dem Startbildschirm eine Schaltfläche "Highscores" hinzu, über die der Benutzer die Highscore-Tabelle direkt vom Hauptmenü aus einsehen kann.

- Fügt eine neue Schaltfläche zur `start_menu_gui.py` hinzu.
- Implementiert die Callback-Logik in `main.py`, um das `HighscoreWindow` anzuzeigen.